### PR TITLE
Animate home page footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,3 +27,18 @@ body {
 /* Accent utilities and helpers */
 .btn-primary { @apply rounded-full bg-orange-600 text-white px-5 py-3 font-medium hover:bg-orange-700; }
 .section { @apply py-12 sm:py-16; }
+
+@keyframes footer-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.footer-fade-in {
+  animation: footer-fade-in 0.6s ease-out forwards;
+}

--- a/src/components/ConnectBanner.tsx
+++ b/src/components/ConnectBanner.tsx
@@ -5,7 +5,7 @@ export default function ConnectBanner() {
   return (
     <section className="mt-16">
       {/* Full-bleed dark block that hugs screen edges */}
-      <div className="bg-zinc-900 text-white rounded-t-[36px]">
+      <div className="bg-zinc-900 text-white rounded-t-[36px] footer-fade-in">
         <div className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
           <div className="flex items-center justify-between gap-6">
             <h2 className="text-3xl sm:text-4xl font-extrabold">Lets Connect there</h2>


### PR DESCRIPTION
## Summary
- add reusable `footer-fade-in` keyframe and class
- apply fade-in animation to the home page footer banner

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c00359eb6083209de68bc22bbcac1f