### PR TITLE
Minor: Tweaked placement of tagline on home page

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -50,7 +50,7 @@ function HeroVisual() {
           initial={{ opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.1 }}
-          className="pointer-events-none select-none absolute top-[22%] left-1/2 -translate-x-1/2 z-20 text-center font-extrabold tracking-tight text-zinc-900 dark:text-white opacity-100 leading-[0.92] w-auto flex flex-col items-center gap-1"
+          className="pointer-events-none select-none absolute top-[27%] left-1/2 -translate-x-1/2 z-20 text-center font-extrabold tracking-tight text-zinc-900 dark:text-white opacity-100 leading-[0.92] w-auto flex flex-col items-center gap-1"
         >
           <span className="block text-[clamp(2rem,5vw,3.5rem)] whitespace-nowrap">I’m Archit,</span>
           <span className="block text-[clamp(2rem,5vw,3.5rem)] whitespace-nowrap">Data Scientist</span>


### PR DESCRIPTION
## Summary

Migrate personal portfolio to a Next.js App Router app and apply the Ocean Sunset palette with light/dark themes. Split into dedicated pages for Data Science and Photography, add an About section, resume link, and a recruiter JD box.

## Changes

- Next.js app scaffold with app router and global theme
- Pages: Home (`/`), Data Science (`/datascience`), Photography (`/photography`)
- Ocean Sunset palette with palette-aware variables and header theme toggle
- About Me, Technical Expertise, Skills, Resume link
- "Am I Fit For Your Job?" JD paste box (copy, download, email compose)
- Data-driven content: `data/projects.json`, `data/photos.json`
- Assets moved to `public/` and placeholder images updated

## How to Run

```bash
npm install
npm run dev
open http://localhost:3000
```

## Notes

- Photography page uses a pastel variant of the palette.
- Theme preference persists via localStorage.

